### PR TITLE
feat: add terraform template for deployment on AWS

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform/
+terraform.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,31 @@
+# Terraform template for deploying Avatarify on AWS
+
+By using this template, you should be able to spawn an EC2 instance with Avatarify pre-installed as a systemd service within 5 minutes.
+
+## Prerequisites
+
+1. Terraform CLI >= 1.12
+2. AWS CLI installed and configured
+3. **Your AWS account must be allowed to create a G instance with 4 vCPUs (you can open a ticket to request a higher quota if you have reached the limit)**
+
+## How-to
+
+1. Verify and change the parameters in [input.tfvars](input.tfvars) according to your needs
+2. Execute the following command to initialize the infrastructure
+
+```
+$ terraform apply -var-file input.tfvars
+<redacted logs>
+Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+instance_public_ip = <some_ip_addr>
+```
+
+3. When the provisionning process is done, the server will be restarted. After a few seconds, you can now connect the avatarify client to the server using the `instance_public_ip` from the above output
+4. (Optional) You can also ssh to the server using the `instance_public_ip` and the ssh private key configured in [input.tfvars](input.tfvars)
+
+```
+$ ssh ubuntu@<instance_public_ip> -i /path/to/private/key
+```

--- a/terraform/cloud-init.sh
+++ b/terraform/cloud-init.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+# Sleep for a while in case the OS is not fully bootstrapped
+for i in $(seq 1 10)
+do
+    echo "sleep $i/10"
+    sleep 1
+done
+
+#####
+# Install softwares & dependencies
+#####
+
+sudo apt-get update
+sudo apt-get install -y gcc make linux-headers-$(uname -r) unzip libsm6 libxext6 libxrender-dev awscli
+
+cat << EOF | sudo tee -a /etc/modprobe.d/blacklist.conf
+blacklist vga16fb
+blacklist nouveau
+blacklist rivafb
+blacklist nvidiafb
+blacklist rivatv
+EOF
+
+echo 'GRUB_CMDLINE_LINUX="rdblacklist=nouveau"' | sudo tee -a /etc/default/grub
+sudo update-grub
+
+aws s3 cp --recursive s3://nvidia-gaming/linux/latest/ .
+unzip GRID-445.48-Apr2020-vGaming-Linux-Guest-Drivers.zip
+rm GRID-445.48-Apr2020-vGaming-Linux-Guest-Drivers.zip
+
+cd Linux/
+chmod +x NVIDIA-Linux-x86_64*.run
+sudo ./NVIDIA-Linux-x86_64*.run -s
+cat << EOF | sudo tee -a /etc/nvidia/gridd.conf
+vGamingMarketplace=2
+EOF
+cd ..
+
+sudo curl -o /etc/nvidia/GridSwCert.txt "https://nvidia-gaming.s3.amazonaws.com/GridSwCert-Archive/GridSwCert-Linux_2020_04.cert"
+
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda3
+rm Miniconda3-latest-Linux-x86_64.sh
+
+git clone https://github.com/alievk/avatarify.git
+cd avatarify/
+wget -O vox-adv-cpk.pth.tar https://www.dropbox.com/s/t7h24l6wx9vreto/vox-adv-cpk.pth.tar?dl=1
+source $HOME/miniconda3/bin/activate
+scripts/install.sh --no-vcam
+
+#####
+# Install systemd service
+#####
+
+SERVICE_FILE_PATH="/etc/systemd/system/avatarify.service"
+SCRIPT_FILE_PATH="/usr/local/bin/start-avatarify.sh"
+
+cat << EOF | sudo tee "$SERVICE_FILE_PATH" > /dev/null
+[Unit]
+Description=Avatarify worker
+Requires=network.target
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart="$SCRIPT_FILE_PATH"
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat << EOF | sudo tee "$SCRIPT_FILE_PATH" > /dev/null
+#!/bin/bash
+
+cd /home/ubuntu/avatarify
+source /home/ubuntu/miniconda3/bin/activate
+conda activate avatarify
+bash run.sh --is-worker
+EOF
+
+sudo chmod +x "$SCRIPT_FILE_PATH"
+
+sudo systemctl daemon-reload
+sudo systemctl enable avatarify
+sudo systemctl start avatarify
+
+#####
+# Installation done, time to reboot :)
+#####
+
+sleep 5 && sudo reboot &

--- a/terraform/input.tfvars
+++ b/terraform/input.tfvars
@@ -1,0 +1,11 @@
+# awscli configs
+aws_profile = "default"
+aws_region  = "eu-west-3"
+
+# IP ranges that are allowed to connect to any port of the server
+# Default value : any ip address /!\
+trusted_cidr_blocks = ["0.0.0.0/0"]
+
+# Paths to the ssh public + private key used to connect to the server
+ssh_private_key = "id"
+ssh_public_key  = "id.pub"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,130 @@
+##################################################
+# Variables
+##################################################
+
+variable "aws_profile" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "trusted_cidr_blocks" {
+  type = list(string)
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "ssh_private_key" {
+  type = string
+}
+
+##################################################
+# Provider
+##################################################
+
+terraform {
+  required_providers {
+    aws      = ">= 2.63.0"
+    template = ">= 2.1.2"
+  }
+}
+
+provider "aws" {
+  profile = var.aws_profile
+  region  = var.aws_region
+}
+
+##################################################
+# Security policies
+##################################################
+
+resource "aws_iam_role" "avatarify" {
+  name = "avatarify"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_policy_attachment" "avatarify" {
+  name       = "avatarify"
+  roles      = [aws_iam_role.avatarify.name]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_instance_profile" "avatarify" {
+  name = "avatarify"
+  role = aws_iam_role.avatarify.name
+}
+
+resource "aws_default_vpc" "default" {}
+
+resource "aws_security_group" "avatarify" {
+  name_prefix = "avatarify"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = var.trusted_cidr_blocks
+  }
+
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+}
+
+##################################################
+# EC2 Instance
+##################################################
+
+resource "aws_key_pair" "avatarify" {
+  key_name   = "avatarify"
+  public_key = file(var.ssh_public_key)
+}
+
+resource "aws_instance" "avatarify" {
+  ami           = "ami-08c757228751c5335" # ubuntu 18.04
+  instance_type = "g4dn.xlarge"
+
+  key_name             = aws_key_pair.avatarify.key_name
+  iam_instance_profile = aws_iam_instance_profile.avatarify.name
+  security_groups      = [aws_security_group.avatarify.name]
+
+  provisioner "remote-exec" {
+    connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = "ubuntu"
+      private_key = file(var.ssh_private_key)
+    }
+
+    script = "cloud-init.sh"
+  }
+}
+
+output "instance_public_ip" {
+  value = aws_instance.avatarify.public_ip
+}


### PR DESCRIPTION
Hello guys, after a few days enjoying avatarify and sharing tons of funny moments with my coworkers, I decide to contribute to the project the terraform template that I used to instantiate a avatarify worker on EC2 (as described in the [wiki](https://github.com/alievk/avatarify/wiki/Provisioning-a-cloud-based-GPU-instance)). Avatarify will be installed as a systemd service with auto-restart capability and be ready for connections right after the provisionning process is done. Users should now be able to spawn an avatarify instance within 5 minutes :)

Feel free to leave your thoughts about the PR!