### PR TITLE
fix(sec): upgrade pyyaml to 5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ opencv-python==4.2.0.34
 face-alignment==1.3.3
 pyzmq==20.0.0
 msgpack-numpy==0.4.7.1
-pyyaml==5.3.1
+pyyaml==5.4
 requests==2.25.1
 pyfakewebcam==0.1.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in pyyaml 5.3.1
- [CVE-2020-14343](https://www.oscs1024.com/hd/CVE-2020-14343)


### What did I do？
Upgrade pyyaml from 5.3.1 to 5.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS