### PR TITLE
fix: Adding version to ngrok config in colab notebook

### DIFF
--- a/avatarify.ipynb
+++ b/avatarify.ipynb
@@ -419,6 +419,7 @@
       "source": [
         "config =\\\n",
         "f\"\"\"\n",
+        "version: 2\n",
         "authtoken: {authtoken}\n",
         "region: {region}\n",
         "console_ui: False\n",


### PR DESCRIPTION
PM from ngrok here. the latest ngrok agent requires a version number in the config file.